### PR TITLE
added .material files for each geds imaging material set

### DIFF
--- a/Gems/pbr_material_pack_mps/Assets/Materials/Blued Steel/blued_steel.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Blued Steel/blued_steel.material
@@ -1,0 +1,13 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/BasePBR.materialtype",
+    "materialTypeVersion": 1,
+    "propertyValues": {
+        "baseColor.textureMap": "Blued_Steel_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "metallic.textureMap": "Blued_Steel_metallic.png",
+        "normal.textureMap": "Blued_Steel_normal.png",
+        "roughness.textureMap": "Blued_Steel_roughness.png",
+        "specularF0.enableMultiScatterCompensation": true
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Braided Steel Cable/Braided_Steel_Cable_cavity.png
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Braided Steel Cable/Braided_Steel_Cable_cavity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65bb9584ce9780cb1948804458b1d36b4ab66f7b0ee803aa351f1c09f462de26
+size 6067413

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Braided Steel Cable/braided_steele_cable.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Braided Steel Cable/braided_steele_cable.material
@@ -1,0 +1,15 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Braided_Steel_Cable_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "metallic.textureMap": "Braided_Steel_Cable_metallic.png",
+        "normal.textureMap": "Braided_Steel_Cable_normal.png",
+        "occlusion.diffuseTextureMap": "Braided_Steel_Cable_ambientOcclusion.png",
+        "occlusion.specularTextureMap": "Braided_Steel_Cable_cavity.png",
+        "roughness.textureMap": "Braided_Steel_Cable_roughness.png",
+        "specularF0.enableMultiScatterCompensation": true
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Carbon Fiber/Carbon_Fiber_cavity.png
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Carbon Fiber/Carbon_Fiber_cavity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9886d9acf292bb0926e9df45d848910c48a578a474d337f495b6f1b6f811481
+size 14940142

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Carbon Fiber/carbon_fiber.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Carbon Fiber/carbon_fiber.material
@@ -1,0 +1,18 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/EnhancedPBR.materialtype",
+    "materialTypeVersion": 6,
+    "propertyValues": {
+        "anisotropy.enableAnisotropy": true,
+        "baseColor.textureMap": "Carbon_Fiber_basecolor.png",
+        "clearCoat.enable": true,
+        "clearCoat.roughnessMap": "Carbon_Fiber_coatRoughness.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "metallic.textureMap": "Carbon_Fiber_metallic.png",
+        "normal.textureMap": "Carbon_Fiber_normal.png",
+        "occlusion.diffuseTextureMap": "Carbon_Fiber_ambientOcclusion.png",
+        "occlusion.specularTextureMap": "Carbon_Fiber_cavity.png",
+        "roughness.textureMap": "Carbon_Fiber_roughness.png",
+        "specularF0.enableMultiScatterCompensation": true
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Clean Grass/Clean_Grass_cavity_ao.png
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Clean Grass/Clean_Grass_cavity_ao.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c71e4433cf835123c84377a3dd0b8b805ba83d63c2c7adfde4f17e9785f5f450
+size 18979802

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Clean Grass/clean_grass.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Clean Grass/clean_grass.material
@@ -1,0 +1,13 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Clean_Grass_basecolor.png",
+        "general.applySpecularAA": true,
+        "normal.textureMap": "Clean_Grass_normal.png",
+        "occlusion.diffuseTextureMap": "Clean_Grass_ambientOcclusion.png",
+        "occlusion.specularTextureMap": "Clean_Grass_cavity_ao.png",
+        "roughness.textureMap": "Clean_Grass_roughness.png",
+        "roughness.upperBound": 0.7699999809265137
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Glossy Plastic/glossy_plastic.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Glossy Plastic/glossy_plastic.material
@@ -1,0 +1,11 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/BasePBR.materialtype",
+    "materialTypeVersion": 1,
+    "propertyValues": {
+        "baseColor.textureMap": "Glossy_Plastic_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "normal.textureMap": "Glossy_Plastic_normal.png",
+        "roughness.textureMap": "Glossy_Plastic_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Glossy Plastic/glossy_plastic_spbr.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Glossy Plastic/glossy_plastic_spbr.material
@@ -1,0 +1,12 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Glossy_Plastic_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "normal.textureMap": "Glossy_Plastic_normal.png",
+        "occlusion.diffuseTextureMap": "Glossy_Plastic_ambientOcclusion.png",
+        "roughness.textureMap": "Glossy_Plastic_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Matte Gold/matte_gold.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Matte Gold/matte_gold.material
@@ -1,0 +1,13 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Matte_Gold_basecolor.png",
+        "general.applySpecularAA": true,
+        "metallic.textureMap": "Matte_Gold_metallic.png",
+        "normal.textureMap": "Matte_Gold_normal.png",
+        "occlusion.diffuseTextureMap": "Matte_Gold_ambientOcclusion.png",
+        "roughness.textureMap": "Matte_Gold_roughness.png",
+        "specularF0.enableMultiScatterCompensation": true
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Mud/Mudcavity_ao.png
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Mud/Mudcavity_ao.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bedb6c27faea0ef7da682485059f3e2d5270e85608fc8eac1e6867d41b32c737
+size 21582809

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Mud/mud.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Mud/mud.material
@@ -1,0 +1,12 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Mud_basecolor.png",
+        "normal.textureMap": "Mud_normal.png",
+        "occlusion.diffuseTextureMap": "Mud_ambientOcclusion.png",
+        "occlusion.specularTextureMap": "Mudcavity_ao.png",
+        "roughness.textureMap": "Mud_roughness.png",
+        "roughness.upperBound": 0.75
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Patchy Grass/Patchy_Grass_cavity_ao.png
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Patchy Grass/Patchy_Grass_cavity_ao.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83828aac4bf1cd527780d468d2a17fcab828d1da354d7d9d865a5e4fb93e3a1c
+size 18534957

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Patchy Grass/patchy_grass.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Patchy Grass/patchy_grass.material
@@ -1,0 +1,13 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Patchy_Grass_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "normal.textureMap": "Patchy_Grass_normal.png",
+        "occlusion.diffuseTextureMap": "Patchy_Grass_ambientOcclusion.png",
+        "occlusion.specularTextureMap": "Patchy_Grass_cavity_ao.png",
+        "roughness.textureMap": "Patchy_Grass_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Perforated Steel/perforated_steele.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Perforated Steel/perforated_steele.material
@@ -1,0 +1,19 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Perforated_Steel_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "metallic.factor": 1.0,
+        "normal.textureMap": "Perforated_Steel_normal.png",
+        "occlusion.diffuseTextureMap": "Perforated_Steel_ambientOcclusion.png",
+        "occlusion.specularTextureMap": "Perforated_Steel_ambientOcclusion.png",
+        "opacity.alphaSource": "Split",
+        "opacity.factor": 0.10000000149011612,
+        "opacity.mode": "Cutout",
+        "opacity.textureMap": "Perforated_Steel_opacity.png",
+        "roughness.textureMap": "Perforated_Steel_roughness.png",
+        "specularF0.enableMultiScatterCompensation": true
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Polished Gold/polished_gold.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Polished Gold/polished_gold.material
@@ -1,0 +1,19 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/BasePBR.materialtype",
+    "materialTypeVersion": 1,
+    "propertyValues": {
+        "baseColor.color": [
+            0.9803921580314636,
+            0.8392156958580017,
+            0.4000000059604645,
+            1.0
+        ],
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "metallic.factor": 1.0,
+        "metallic.textureMap": "Polished_Gold_metallic.png",
+        "normal.textureMap": "Polished_Gold_normal.png",
+        "roughness.factor": 0.3799999952316284,
+        "specularF0.enableMultiScatterCompensation": true
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Raked Dirt Ground/raked_dirt_ground.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Raked Dirt Ground/raked_dirt_ground.material
@@ -1,0 +1,12 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Raked_Dirt_Ground_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "normal.textureMap": "Raked_Dirt_Ground_normal.png",
+        "occlusion.diffuseTextureMap": "Raked_Dirt_Ground_ambientOcclusion.png",
+        "roughness.textureMap": "Raked_Dirt_Ground_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Rocky Dirt/rocky_dirt.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Rocky Dirt/rocky_dirt.material
@@ -1,0 +1,12 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Rocky_Dirt_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "normal.textureMap": "Rocky_Dirt_normal.png",
+        "occlusion.diffuseTextureMap": "Rocky_Dirt_ambientOcclusion.png",
+        "roughness.textureMap": "Rocky_Dirt_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Rough Plastic/rough_plastic.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Rough Plastic/rough_plastic.material
@@ -1,0 +1,11 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/BasePBR.materialtype",
+    "materialTypeVersion": 1,
+    "propertyValues": {
+        "baseColor.textureMap": "Rough_Plastic_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "normal.textureMap": "Rough_Plastic_normal.png",
+        "roughness.textureMap": "Rough_Plastic_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Rough Rubber/Rough_Rubber_cavity_ao.png
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Rough Rubber/Rough_Rubber_cavity_ao.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a84ef47a605e7eef2f7fac2b1d536eb861aeb15c7efc0aa6f454b35590a9a00
+size 6047972

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Rough Rubber/rough_rubber.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Rough Rubber/rough_rubber.material
@@ -1,0 +1,11 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/BasePBR.materialtype",
+    "materialTypeVersion": 1,
+    "propertyValues": {
+        "baseColor.textureMap": "Rough_Rubber_basecolor.png",
+        "general.applySpecularAA": true,
+        "irradiance.irradianceColorSource": "BaseColor",
+        "normal.textureMap": "Rough_Rubber_normal.png",
+        "roughness.textureMap": "Rough_Rubber_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Rough Rubber/rough_rubber_spbr.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Rough Rubber/rough_rubber_spbr.material
@@ -1,0 +1,19 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.color": [
+            0.19607843458652496,
+            0.20000000298023224,
+            0.20000000298023224,
+            1.0
+        ],
+        "baseColor.textureBlendMode": "Lerp",
+        "baseColor.textureMap": "Rough_Rubber_basecolor.png",
+        "general.applySpecularAA": true,
+        "normal.textureMap": "Rough_Rubber_normal.png",
+        "occlusion.diffuseTextureMap": "Rough_Rubber_ambientOcclusion.png",
+        "occlusion.specularTextureMap": "Rough_Rubber_cavity_ao.png",
+        "roughness.textureMap": "Rough_Rubber_roughness.png"
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Tinted Glass/tinted_glass.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Tinted Glass/tinted_glass.material
@@ -1,0 +1,13 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Tinted_Glass_basecolor.png",
+        "normal.textureMap": "Tinted_Glass_normal.png",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.4000000059604645,
+        "opacity.mode": "TintedTransparent",
+        "opacity.textureMap": "Tinted_Glass_opacity.png",
+        "roughness.factor": 0.019999999552965164
+    }
+}

--- a/Gems/pbr_material_pack_mps/Assets/Materials/Treated Sand Garden/treated_sand_garden.material
+++ b/Gems/pbr_material_pack_mps/Assets/Materials/Treated Sand Garden/treated_sand_garden.material
@@ -1,0 +1,10 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "baseColor.textureMap": "Treated_Sand_Garden_basecolor.png",
+        "normal.textureMap": "Treated_Sand_Garden_normal.png",
+        "occlusion.diffuseTextureMap": "Treated_Sand_Garden_ambientOcclusion.png",
+        "roughness.textureMap": "Treated_Sand_Garden_roughness.png"
+    }
+}


### PR DESCRIPTION
1. Added a .material for each
2. Not tuned in level, they may need adjustments
3. Glass likely won't work super well if viewing through multiple layers of it (non-sorted), and we don't have refection
4. There may not be a great sense of scale (how many meters does this material pixel frequency represent.)

You may need to add to objects in the level, like a ground plane, and use the material instance editor to tweak the UV scale/tiling and then push those changes back to the source material.

Signed-off-by: Jonny Galloway <gallowj@amazon.com>