### PR TITLE
Minor kb3d fixes

### DIFF
--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Bench_A/HTS_Bench_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Bench_A/HTS_Bench_A.prefab
@@ -3,10 +3,6 @@
         "Id": "ContainerEntity",
         "Name": "HTS_Bench_A",
         "Components": {
-            "Component_[12045762681586940809]": {
-                "$type": "SelectionComponent",
-                "Id": 12045762681586940809
-            },
             "Component_[13479950991503042358]": {
                 "$type": "EditorInspectorComponent",
                 "Id": 13479950991503042358
@@ -79,6 +75,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1820864736712061341,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {},
@@ -209,10 +212,6 @@
                             }
                         }
                     }
-                },
-                "Component_[9863474473349343216]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9863474473349343216
                 }
             }
         }

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_A.prefab
@@ -173,9 +173,8 @@
                                     "Value": {
                                         "MaterialAsset": {
                                             "assetId": {
-                                                "guid": "{6165DB87-3DF2-5987-9452-DA3C380DED18}"
-                                            },
-                                            "assetHint": "kb3d_hightechstreets/objects/hts_patha_a/hts_patha_a_kb3d_hts_plasticwhite.azmaterial"
+                                                "guid": "{80F97D8B-7F94-5A94-9F06-18014BB875E6}"
+                                            }
                                         }
                                     }
                                 },


### PR DESCRIPTION
This fixes the rubber material on the PathA_A model.  Somehow in the prefab it was set to white plastic.  Also fixes invalid SelectionComponent warning in the bench prefab.