### PR TITLE
Fix YBot FBX Settings

### DIFF
--- a/Gems/character_mps/Assets/Mixamo/Ybot/ybot.fbx.assetinfo
+++ b/Gems/character_mps/Assets/Mixamo/Ybot/ybot.fbx.assetinfo
@@ -4,106 +4,173 @@
             "$type": "ActorGroup",
             "name": "YBot",
             "selectedRootBone": "RootNode",
-            "id": "{2B3CB90B-3337-5419-A80F-357D39CC4AC7}"
-        },
-        {
-            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
-            "id": "{7035EA37-6748-5526-9FAF-DF8ED5FABB3C}",
-            "name": "YBot",
-            "NodeSelectionList": {
-                "unselectedNodes": [
-                    {},
-                    "RootNode",
-                    "RootNode.YBot",
-                    "RootNode.Armature",
-                    "RootNode.YBot.YBot_LOD0",
-                    "RootNode.Armature.mixamorig:Hips",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Logo_lod0",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Joints_lod0",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Surface_lod0",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase.mixamorig:LeftToe_End",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase.mixamorig:RightToe_End",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head.mixamorig:HeadTop_End",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase.mixamorig:LeftToe_End.mixamorig:LeftToe_End_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase.mixamorig:RightToe_End.mixamorig:RightToe_End_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head.mixamorig:HeadTop_End.mixamorig:HeadTop_End_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3.mixamorig:LeftHandThumb4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3.mixamorig:LeftHandIndex4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3.mixamorig:LeftHandMiddle4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3.mixamorig:LeftHandRing4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3.mixamorig:LeftHandPinky4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3.mixamorig:RightHandThumb4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3.mixamorig:RightHandIndex4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3.mixamorig:RightHandMiddle4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3.mixamorig:RightHandRing4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3.mixamorig:RightHandPinky4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3.mixamorig:LeftHandThumb4.mixamorig:LeftHandThumb4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3.mixamorig:LeftHandIndex4.mixamorig:LeftHandIndex4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3.mixamorig:LeftHandMiddle4.mixamorig:LeftHandMiddle4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3.mixamorig:LeftHandRing4.mixamorig:LeftHandRing4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3.mixamorig:LeftHandPinky4.mixamorig:LeftHandPinky4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3.mixamorig:RightHandThumb4.mixamorig:RightHandThumb4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3.mixamorig:RightHandIndex4.mixamorig:RightHandIndex4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3.mixamorig:RightHandMiddle4.mixamorig:RightHandMiddle4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3.mixamorig:RightHandRing4.mixamorig:RightHandRing4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3.mixamorig:RightHandPinky4.mixamorig:RightHandPinky4_end"
-                ]
-            },
-            "PhysicsMaterialSlots": {
-                "Slots": [
+            "id": "{2B3CB90B-3337-5419-A80F-357D39CC4AC7}",
+            "rules": {
+                "rules": [
                     {
-                        "Name": "Entire object"
+                        "$type": "MetaDataRule",
+                        "metaData": "AdjustActor -actorID $(ACTORID) -name \"YBot\"\nActorSetCollisionMeshes -actorID $(ACTORID) -lod 0 -nodeList \"\"\nAdjustActor -actorID $(ACTORID) -nodesExcludedFromBounds \"\" -nodeAction \"select\"\nAdjustActor -actorID $(ACTORID) -nodeAction \"replace\" -attachmentNodes \"\"\nAdjustActor -actorID $(ACTORID) -motionExtractionNodeName \"RootNode\"\nAdjustActor -actorID $(ACTORID) -mirrorSetup \"\"\n"
+                    },
+                    {
+                        "$type": "{3CB103B3-CEAF-49D7-A9DC-5A31E2DF15E4} LodRule",
+                        "nodeSelectionList": [
+                            {
+                                "selectedNodes": [
+                                    "RootNode",
+                                    "RootNode.Armature",
+                                    "RootNode.Armature.mixamorig:Hips",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head"
+                                ],
+                                "unselectedNodes": [
+                                    "RootNode.YBot_LOD_Group",
+                                    "RootNode.YBot_LOD_Group.LOD2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Joints_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Body_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Head_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Joints_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Logo_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Body_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Head_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Joints_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Logo_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Body_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Head_lod0"
+                                ]
+                            },
+                            {
+                                "selectedNodes": [
+                                    "RootNode",
+                                    "RootNode.Armature",
+                                    "RootNode.Armature.mixamorig:Hips",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm"
+                                ],
+                                "unselectedNodes": [
+                                    "RootNode.YBot_LOD_Group",
+                                    "RootNode.YBot_LOD_Group.LOD2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Joints_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Body_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Head_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Joints_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Logo_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Body_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Head_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Joints_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Logo_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Body_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Head_lod0",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3"
+                                ]
+                            }
+                        ]
                     }
                 ]
             }
@@ -113,21 +180,35 @@
             "name": "YBot",
             "nodeSelectionList": {
                 "selectedNodes": [
-                    {},
+                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Head_lod0",
+                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Body_lod0",
+                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Logo_lod0",
+                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Joints_lod0"
+                ],
+                "unselectedNodes": [
                     "RootNode",
-                    "RootNode.YBot",
                     "RootNode.Armature",
-                    "RootNode.YBot.YBot_LOD0",
+                    "RootNode.YBot_LOD_Group",
                     "RootNode.Armature.mixamorig:Hips",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Logo_lod0",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Joints_lod0",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Surface_lod0",
+                    "RootNode.YBot_LOD_Group.LOD0",
+                    "RootNode.YBot_LOD_Group.LOD1",
+                    "RootNode.YBot_LOD_Group.LOD2",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg",
+                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0",
+                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1",
+                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg",
+                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Head_lod1",
+                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Body_lod1",
+                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Logo_lod1",
+                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Joints_lod1",
+                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Head_lod2",
+                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Body_lod2",
+                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Joints_lod2",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot",
@@ -139,14 +220,8 @@
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase.mixamorig:LeftToe_End",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase.mixamorig:RightToe_End",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head.mixamorig:HeadTop_End",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase.mixamorig:LeftToe_End.mixamorig:LeftToe_End_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase.mixamorig:RightToe_End.mixamorig:RightToe_End_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head.mixamorig:HeadTop_End.mixamorig:HeadTop_End_end",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1",
@@ -178,27 +253,7 @@
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3",
                     "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3.mixamorig:LeftHandThumb4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3.mixamorig:LeftHandIndex4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3.mixamorig:LeftHandMiddle4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3.mixamorig:LeftHandRing4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3.mixamorig:LeftHandPinky4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3.mixamorig:RightHandThumb4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3.mixamorig:RightHandIndex4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3.mixamorig:RightHandMiddle4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3.mixamorig:RightHandRing4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3.mixamorig:RightHandPinky4",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3.mixamorig:LeftHandThumb4.mixamorig:LeftHandThumb4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3.mixamorig:LeftHandIndex4.mixamorig:LeftHandIndex4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3.mixamorig:LeftHandMiddle4.mixamorig:LeftHandMiddle4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3.mixamorig:LeftHandRing4.mixamorig:LeftHandRing4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3.mixamorig:LeftHandPinky4.mixamorig:LeftHandPinky4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3.mixamorig:RightHandThumb4.mixamorig:RightHandThumb4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3.mixamorig:RightHandIndex4.mixamorig:RightHandIndex4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3.mixamorig:RightHandMiddle4.mixamorig:RightHandMiddle4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3.mixamorig:RightHandRing4.mixamorig:RightHandRing4_end",
-                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3.mixamorig:RightHandPinky4.mixamorig:RightHandPinky4_end"
+                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3"
                 ]
             },
             "rules": {
@@ -208,99 +263,99 @@
                     },
                     {
                         "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule",
+                        "nodeSelectionList": [
+                            {
+                                "selectedNodes": [
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Head_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Mesh_Body_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Logo_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1.Alpha_Joints_lod1"
+                                ],
+                                "unselectedNodes": [
+                                    "RootNode",
+                                    "RootNode.Armature",
+                                    "RootNode.YBot_LOD_Group",
+                                    "RootNode.Armature.mixamorig:Hips",
+                                    "RootNode.YBot_LOD_Group.LOD0",
+                                    "RootNode.YBot_LOD_Group.LOD1",
+                                    "RootNode.YBot_LOD_Group.LOD2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD1.Alpha_mesh_final_lod1",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Head_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Mesh_Body_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Logo_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD0.Alpha_mesh_final_lod0.Alpha_Joints_lod0",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Head_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Mesh_Body_lod2",
+                                    "RootNode.YBot_LOD_Group.LOD2.Alpha_mesh_final_lod2.Alpha_Joints_lod2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:LeftUpLeg.mixamorig:LeftLeg.mixamorig:LeftFoot.mixamorig:LeftToeBase",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:RightUpLeg.mixamorig:RightLeg.mixamorig:RightFoot.mixamorig:RightToeBase",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:Neck.mixamorig:Head",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandThumb1.mixamorig:LeftHandThumb2.mixamorig:LeftHandThumb3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandIndex1.mixamorig:LeftHandIndex2.mixamorig:LeftHandIndex3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandMiddle1.mixamorig:LeftHandMiddle2.mixamorig:LeftHandMiddle3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandRing1.mixamorig:LeftHandRing2.mixamorig:LeftHandRing3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:LeftShoulder.mixamorig:LeftArm.mixamorig:LeftForeArm.mixamorig:LeftHand.mixamorig:LeftHandPinky1.mixamorig:LeftHandPinky2.mixamorig:LeftHandPinky3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandThumb1.mixamorig:RightHandThumb2.mixamorig:RightHandThumb3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandIndex1.mixamorig:RightHandIndex2.mixamorig:RightHandIndex3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandMiddle1.mixamorig:RightHandMiddle2.mixamorig:RightHandMiddle3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandRing1.mixamorig:RightHandRing2.mixamorig:RightHandRing3",
+                                    "RootNode.Armature.mixamorig:Hips.mixamorig:Spine.mixamorig:Spine1.mixamorig:Spine2.mixamorig:RightShoulder.mixamorig:RightArm.mixamorig:RightForeArm.mixamorig:RightHand.mixamorig:RightHandPinky1.mixamorig:RightHandPinky2.mixamorig:RightHandPinky3"
+                                ]
+                            }
+                        ]
                     }
                 ]
             },
             "id": "{D1DFBD88-CA92-5304-A744-87BFE32FC9EB}"
         },
         {
-            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
-            "name": "default_YBot_51595355_1C1C_5586_A93F_E9599497AFFB_",
-            "nodeSelectionList": {
-                "selectedNodes": [
-                    "RootNode.YBot.YBot_LOD0.Alpha_Logo_lod0"
-                ],
-                "unselectedNodes": [
-                    "RootNode.YBot.YBot_LOD0.Alpha_Joints_lod0",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Surface_lod0"
-                ]
-            },
-            "rules": {
-                "rules": [
-                    {
-                        "$type": "ProceduralMeshGroupRule"
-                    },
-                    {
-                        "$type": "CoordinateSystemRule",
-                        "useAdvancedData": true
-                    },
-                    {
-                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
-                    }
-                ]
-            },
-            "id": "{51595355-1C1C-5586-A93F-E9599497AFFB}"
-        },
-        {
-            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
-            "name": "default_YBot_809C0AB6_2FA8_5898_9652_758DAF736CB5_",
-            "nodeSelectionList": {
-                "selectedNodes": [
-                    "RootNode.YBot.YBot_LOD0.Alpha_Joints_lod0"
-                ],
-                "unselectedNodes": [
-                    "RootNode.YBot.YBot_LOD0.Alpha_Logo_lod0",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Surface_lod0"
-                ]
-            },
-            "rules": {
-                "rules": [
-                    {
-                        "$type": "ProceduralMeshGroupRule"
-                    },
-                    {
-                        "$type": "CoordinateSystemRule",
-                        "useAdvancedData": true
-                    },
-                    {
-                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
-                    }
-                ]
-            },
-            "id": "{809C0AB6-2FA8-5898-9652-758DAF736CB5}"
-        },
-        {
-            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
-            "name": "default_YBot_D515D346_1A4B_51A5_9D40_F4C085B58E7B_",
-            "nodeSelectionList": {
-                "selectedNodes": [
-                    "RootNode.YBot.YBot_LOD0.Alpha_Surface_lod0"
-                ],
-                "unselectedNodes": [
-                    "RootNode.YBot.YBot_LOD0.Alpha_Logo_lod0",
-                    "RootNode.YBot.YBot_LOD0.Alpha_Joints_lod0"
-                ]
-            },
-            "rules": {
-                "rules": [
-                    {
-                        "$type": "ProceduralMeshGroupRule"
-                    },
-                    {
-                        "$type": "CoordinateSystemRule",
-                        "useAdvancedData": true
-                    },
-                    {
-                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
-                    }
-                ]
-            },
-            "id": "{D515D346-1A4B-51A5-9D40-F4C085B58E7B}"
-        },
-        {
             "$type": "PrefabGroup",
-            "name": "Mixamo/Ybot/YBot_fbx.procprefab",
-            "id": "{42BC3AD6-1A2A-5EF4-A2C3-4D2E9AE937EE}"
+            "name": "Mixamo/Ybot/ybot_fbx.procprefab",
+            "id": "{FEC1C13A-0CC6-5B63-BDE1-C44CC569735F}",
+            "createProceduralPrefab": false
         }
     ]
 }


### PR DESCRIPTION
Fixes an issue where the YBot.fbx was set as a procedural prefab and created a bunch of different meshes, lods and groups that didn't seem to work with the animgraph.  By manually setting up the FBX Settings and LODs the animgraph/root motion works again, however there are some issues:
1. The asset builder fails if Alpha_joints_lod2 is added to an LOD group with the error:
```
BufferAsset: Size of the buffer in the descriptor was 0
BufferAsset: Cannot continue building BufferAsset because 1 error(s) reported
Atom Model Builder: Failed to build index stream
```
2. The vertices of the mesh got assigned differently to the joints than before so there are some noticable stretching issues and deformations - namely the robots seat deforms in an unappealing way when moving
3. The Mixamo/Adobe logo is only a single triangle in LOD 1 so it is not fully displayed.
![image](https://user-images.githubusercontent.com/26804013/210907305-133f1397-8cbc-4943-9b7b-02088027b466.png)


Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>