### PR TITLE
Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Bench_A/HTS_Bench_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Bench_A/HTS_Bench_A.prefab
@@ -76,7 +76,7 @@
                     "Id": 16169812338229402181
                 },
                 "Component_[1820864736712061341]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1820864736712061341,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgLG_D/HTS_BldgLG_D.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgLG_D/HTS_BldgLG_D.prefab
@@ -191,7 +191,7 @@
                     }
                 },
                 "Component_[3019556450410858368]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3019556450410858368,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -687,7 +687,7 @@
                     "Id": 16977468047874161874
                 },
                 "Component_[2974378503878604500]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2974378503878604500,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgLG_F/HTS_BldgLG_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgLG_F/HTS_BldgLG_F.prefab
@@ -139,7 +139,7 @@
                     "Id": 15204717560788297729
                 },
                 "Component_[17851011917298187366]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17851011917298187366,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -395,7 +395,7 @@
                     "Id": 7230428083708752285
                 },
                 "Component_[7744840565632281750]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7744840565632281750,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -639,7 +639,7 @@
                     "Id": 18406402943190521207
                 },
                 "Component_[4055265192360606787]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4055265192360606787,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgLG_I/HTS_BldgLG_I.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgLG_I/HTS_BldgLG_I.prefab
@@ -199,7 +199,7 @@
                     "Id": 4599662175304718014
                 },
                 "Component_[5195980560445368217]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 5195980560445368217,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -357,7 +357,7 @@
                     "Id": 4292385767978019443
                 },
                 "Component_[7208079518264274459]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7208079518264274459,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -518,7 +518,7 @@
                     "Id": 8960703309360449631
                 },
                 "Component_[954109399315587608]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 954109399315587608,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -823,7 +823,7 @@
                     }
                 },
                 "Component_[5195980560445368217]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 5195980560445368217,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -882,7 +882,7 @@
                     "Id": 11219381253240642336
                 },
                 "Component_[12573553797875360289]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12573553797875360289,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_A/HTS_BldgMD_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_A/HTS_BldgMD_A.prefab
@@ -307,7 +307,7 @@
                     ]
                 },
                 "Component_[2979562609108133719]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2979562609108133719,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_C/HTS_BldgMD_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_C/HTS_BldgMD_C.prefab
@@ -151,7 +151,7 @@
                     "Id": 15235821381656933923
                 },
                 "Component_[16889079224290166487]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16889079224290166487,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -460,7 +460,7 @@
                     "Id": 17134293924082278181
                 },
                 "Component_[17623369086815944419]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17623369086815944419,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -598,7 +598,7 @@
                     "Id": 17134293924082278181
                 },
                 "Component_[17623369086815944419]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17623369086815944419,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_E/HTS_BldgMD_E.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_E/HTS_BldgMD_E.prefab
@@ -234,7 +234,7 @@
                     ]
                 },
                 "Component_[13567400293671649133]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13567400293671649133,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_G/HTS_BldgMD_G.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_G/HTS_BldgMD_G.prefab
@@ -71,7 +71,7 @@
                     "Id": 13129914582251903800
                 },
                 "Component_[15266108425615801201]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15266108425615801201,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_J/HTS_BldgMD_J.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgMD_J/HTS_BldgMD_J.prefab
@@ -70,7 +70,7 @@
                     }
                 },
                 "Component_[106296510070123748]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 106296510070123748,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgSM_K/HTS_BldgSM_K.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgSM_K/HTS_BldgSM_K.prefab
@@ -178,7 +178,7 @@
                     "Id": 2283923239303177655
                 },
                 "Component_[3914188279721837584]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3914188279721837584,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgSM_M/HTS_BldgSM_M.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_BldgSM_M/HTS_BldgSM_M.prefab
@@ -92,7 +92,7 @@
                     "Id": 3441541364326297883
                 },
                 "Component_[5451269768190522012]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 5451269768190522012,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Lift_A/HTS_Lift_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Lift_A/HTS_Lift_A.prefab
@@ -124,7 +124,7 @@
                     "Id": 4613011445043635141
                 },
                 "Component_[5602455299727261131]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 5602455299727261131,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Lift_B/HTS_Lift_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Lift_B/HTS_Lift_B.prefab
@@ -59,7 +59,7 @@
                     "Id": 12971470967929346998
                 },
                 "Component_[17533011843146383902]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17533011843146383902,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Lift_C/HTS_Lift_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Lift_C/HTS_Lift_C.prefab
@@ -67,7 +67,7 @@
                     "Id": 14242612754917218143
                 },
                 "Component_[14304491735664610295]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14304491735664610295,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_A/HTS_PathA_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_A/HTS_PathA_A.prefab
@@ -59,7 +59,7 @@
                     "Id": 11974596320341223363
                 },
                 "Component_[14792141984087255965]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14792141984087255965,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_B/HTS_PathA_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_B/HTS_PathA_B.prefab
@@ -76,7 +76,7 @@
                     "Id": 18305393905744934322
                 },
                 "Component_[2322535107225288476]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2322535107225288476,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_C/HTS_PathA_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_C/HTS_PathA_C.prefab
@@ -82,7 +82,7 @@
                     }
                 },
                 "Component_[15003432803399110969]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15003432803399110969,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_D/HTS_PathA_D.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_D/HTS_PathA_D.prefab
@@ -71,7 +71,7 @@
                     "Id": 14170801141593568981
                 },
                 "Component_[15876040400861331371]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15876040400861331371,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_E/HTS_PathA_E.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_E/HTS_PathA_E.prefab
@@ -60,7 +60,7 @@
                     "Parent Entity": "ContainerEntity"
                 },
                 "Component_[11775635604286131361]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11775635604286131361,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_F/HTS_PathA_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathA_F/HTS_PathA_F.prefab
@@ -91,7 +91,7 @@
                     ]
                 },
                 "Component_[12456615943013925679]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12456615943013925679,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_A/HTS_PathB_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_A/HTS_PathB_A.prefab
@@ -116,7 +116,7 @@
                     ]
                 },
                 "Component_[16843386752419967471]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16843386752419967471,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_B/HTS_PathB_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_B/HTS_PathB_B.prefab
@@ -88,7 +88,7 @@
                     "Id": 13768631176440551629
                 },
                 "Component_[18069196046529918403]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 18069196046529918403,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_C/HTS_PathB_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_C/HTS_PathB_C.prefab
@@ -86,7 +86,7 @@
                     "Id": 15503362959124201093
                 },
                 "Component_[15559084538883391016]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15559084538883391016,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_D/HTS_PathB_D.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_D/HTS_PathB_D.prefab
@@ -203,7 +203,7 @@
                     "Id": 7571817197354325512
                 },
                 "Component_[87558059031986691]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 87558059031986691,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_E/HTS_PathB_E.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_E/HTS_PathB_E.prefab
@@ -82,7 +82,7 @@
                     "Id": 17515102151711209093
                 },
                 "Component_[17603766430106210713]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17603766430106210713,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_F/HTS_PathB_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_PathB_F/HTS_PathB_F.prefab
@@ -167,7 +167,7 @@
                     "Id": 1574753712356427762
                 },
                 "Component_[2320157841019514490]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2320157841019514490,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Planter_A/HTS_Planter_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Planter_A/HTS_Planter_A.prefab
@@ -189,7 +189,7 @@
                     "Id": 3911683174015586338
                 },
                 "Component_[7315126566151735774]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7315126566151735774,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Planter_C/HTS_Planter_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Planter_C/HTS_Planter_C.prefab
@@ -70,7 +70,7 @@
                     }
                 },
                 "Component_[12781317673310785298]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12781317673310785298,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_A/HTS_Road_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_A/HTS_Road_A.prefab
@@ -238,7 +238,7 @@
                     "Id": 5143423826339765054
                 },
                 "Component_[8938148536640438723]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8938148536640438723,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_B/HTS_Road_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_B/HTS_Road_B.prefab
@@ -189,7 +189,7 @@
                     "Id": 17614904584715726797
                 },
                 "Component_[1877669616737331169]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1877669616737331169,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_C/HTS_Road_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_C/HTS_Road_C.prefab
@@ -205,7 +205,7 @@
                     "Parent Entity": "ContainerEntity"
                 },
                 "Component_[2855286351398012508]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2855286351398012508,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_D/HTS_Road_D.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_D/HTS_Road_D.prefab
@@ -111,7 +111,7 @@
                     "Id": 3369379742709399289
                 },
                 "Component_[4994980349732420367]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4994980349732420367,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_E/HTS_Road_E.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_E/HTS_Road_E.prefab
@@ -238,7 +238,7 @@
                     "Id": 3371208157595213574
                 },
                 "Component_[8594993827161345312]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8594993827161345312,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_F/HTS_Road_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_F/HTS_Road_F.prefab
@@ -193,7 +193,7 @@
                     }
                 },
                 "Component_[1685564810151699974]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1685564810151699974,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_G/HTS_Road_G.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_G/HTS_Road_G.prefab
@@ -63,7 +63,7 @@
                     "Id": 13487600955080961632
                 },
                 "Component_[14684643097089737868]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14684643097089737868,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_H/HTS_Road_H.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/HTS_Road_H/HTS_Road_H.prefab
@@ -84,7 +84,7 @@
                     "Id": 12150918584341485729
                 },
                 "Component_[14637688770840576110]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14637688770840576110,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/Platform_Tile/Platform_Tile.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Objects/Platform_Tile/Platform_Tile.prefab
@@ -147,7 +147,7 @@
                     "Id": 699587959005635516
                 },
                 "Component_[9490414790499811910]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 9490414790499811910,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgLG_D.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgLG_D.prefab
@@ -119,7 +119,7 @@
                     "Id": 16977468047874161874
                 },
                 "Component_[2974378503878604500]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2974378503878604500,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -360,7 +360,7 @@
                     }
                 },
                 "Component_[3019556450410858368]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3019556450410858368,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1018,7 +1018,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{954AC1D5-683A-59D9-A7B2-06C54994BECA}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_bldglg_d/hts_bldglg_d_kb3d_hts_glassblue.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgLG_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgLG_F.prefab
@@ -215,7 +215,7 @@
                     "Id": 7230428083708752285
                 },
                 "Component_[7744840565632281750]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7744840565632281750,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -353,7 +353,7 @@
                     "Id": 15204717560788297729
                 },
                 "Component_[17851011917298187366]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17851011917298187366,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -707,7 +707,7 @@
             "Name": "hts_bldglg_f_door",
             "Components": {
                 "Component_[10324074718249435122]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 10324074718249435122,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -898,7 +898,7 @@
                     "Id": 2629594388888631224
                 },
                 "Component_[4024189617924325654]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4024189617924325654,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgLG_I.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgLG_I.prefab
@@ -156,7 +156,7 @@
             "Name": "KB3D_HTS_BldgLG_I_Main",
             "Components": {
                 "Component_[12990689598363647862]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12990689598363647862,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -462,7 +462,7 @@
                     "Id": 11219381253240642336
                 },
                 "Component_[12573553797875360289]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12573553797875360289,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -629,7 +629,7 @@
                     "Id": 6035289368489206762
                 },
                 "Component_[6659372289760575026]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6659372289760575026,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_A.prefab
@@ -131,7 +131,7 @@
                     ]
                 },
                 "Component_[2979562609108133719]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2979562609108133719,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -497,7 +497,7 @@
                     "Id": 3679404040708065897
                 },
                 "Component_[516395389871906758]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 516395389871906758,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_C.prefab
@@ -201,7 +201,7 @@
                     "Id": 15235821381656933923
                 },
                 "Component_[16889079224290166487]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16889079224290166487,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -314,7 +314,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11882972241381921570]/Transform Data/Translate/1",
-                    "value": -1.9032955169677734
+                    "value": -1.9032955169677737
                 },
                 {
                     "op": "replace",

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_E.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_E.prefab
@@ -128,7 +128,7 @@
                     "Id": 5813769238523776653
                 },
                 "Component_[6104456434201855018]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6104456434201855018,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -451,7 +451,7 @@
                     "Id": 5402861460008619143
                 },
                 "Component_[6213657016243586033]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6213657016243586033,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -667,7 +667,7 @@
                     "Id": 7233473629587261005
                 },
                 "Component_[7646554545865673656]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7646554545865673656,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -883,7 +883,7 @@
                     "Id": 7233473629587261005
                 },
                 "Component_[7646554545865673656]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7646554545865673656,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_G.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_G.prefab
@@ -55,7 +55,7 @@
             "Name": "hts_bldgmd_g_main",
             "Components": {
                 "Component_[10879530966315323840]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 10879530966315323840,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -397,7 +397,7 @@
                     "Id": 6191479683721622581
                 },
                 "Component_[7464431390310018735]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7464431390310018735,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -600,7 +600,7 @@
                     "Id": 6191479683721622581
                 },
                 "Component_[7464431390310018735]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7464431390310018735,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_J.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgMD_J.prefab
@@ -94,7 +94,7 @@
                     "Id": 17134293924082278181
                 },
                 "Component_[17623369086815944419]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17623369086815944419,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -149,7 +149,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{D8451C96-823C-5973-829F-FA3D296B8F44}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metalyellow.azmaterial"
                                         }
                                     }
                                 },
@@ -161,7 +162,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{8D088D01-CD0D-5919-83EA-D62182792E1D}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_plasticwhite.azmaterial"
                                         }
                                     }
                                 },
@@ -173,7 +175,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{B0F1B1B5-1EF2-5B94-8511-280E9CE590CF}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_lightblue.azmaterial"
                                         }
                                     }
                                 },
@@ -185,7 +188,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{2BD67584-8FB3-5903-9F21-C5AE3F6E7011}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metalwhite.azmaterial"
                                         }
                                     }
                                 },
@@ -197,7 +201,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{04658DE4-DF54-5D41-8A84-1137503ED47D}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metallight.azmaterial"
                                         }
                                     }
                                 },
@@ -209,7 +214,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{1586295D-C5AE-5E8A-B952-4B5C94A6B235}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metalgrey.azmaterial"
                                         }
                                     }
                                 }
@@ -306,7 +312,7 @@
                     "Id": 17134293924082278181
                 },
                 "Component_[17623369086815944419]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17623369086815944419,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -408,7 +414,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{D8451C96-823C-5973-829F-FA3D296B8F44}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metalyellow.azmaterial"
                                         }
                                     }
                                 },
@@ -420,7 +427,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{8D088D01-CD0D-5919-83EA-D62182792E1D}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_plasticwhite.azmaterial"
                                         }
                                     }
                                 },
@@ -432,7 +440,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{B0F1B1B5-1EF2-5B94-8511-280E9CE590CF}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_lightblue.azmaterial"
                                         }
                                     }
                                 },
@@ -444,7 +453,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{2BD67584-8FB3-5903-9F21-C5AE3F6E7011}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metalwhite.azmaterial"
                                         }
                                     }
                                 },
@@ -456,7 +466,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{04658DE4-DF54-5D41-8A84-1137503ED47D}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metallight.azmaterial"
                                         }
                                     }
                                 },
@@ -468,7 +479,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{1586295D-C5AE-5E8A-B952-4B5C94A6B235}"
-                                            }
+                                            },
+                                            "assetHint": "kb3d_hightechstreets/objects/hts_lamp/hts_lamp_kb3d_hts_metalgrey.azmaterial"
                                         }
                                     }
                                 }
@@ -739,7 +751,7 @@
                     ]
                 },
                 "Component_[13795747360665589198]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13795747360665589198,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgSM_M.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_BldgSM_M.prefab
@@ -200,7 +200,7 @@
                     ]
                 },
                 "Component_[3487576162907657499]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3487576162907657499,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lamp.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lamp.prefab
@@ -185,7 +185,7 @@
                     "Id": 17134293924082278181
                 },
                 "Component_[17623369086815944419]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17623369086815944419,
                     "ColliderConfiguration": {
                         "Rotation": [

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lift_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lift_A.prefab
@@ -63,7 +63,7 @@
                     "Id": 12614135572925994443
                 },
                 "Component_[13953719371560068493]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13953719371560068493,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lift_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lift_B.prefab
@@ -129,7 +129,7 @@
                     "Id": 1119589662197032077
                 },
                 "Component_[13062561470622061556]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13062561470622061556,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lift_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lift_C.prefab
@@ -124,7 +124,7 @@
                     "Id": 6222445684391243705
                 },
                 "Component_[7738080774340016580]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7738080774340016580,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_A.prefab
@@ -128,7 +128,7 @@
                     "Id": 6982201770705640002
                 },
                 "Component_[7413500512689093365]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7413500512689093365,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_B.prefab
@@ -55,7 +55,7 @@
             "Name": "hts_patha_b_main",
             "Components": {
                 "Component_[10019525585393226799]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 10019525585393226799,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_C.prefab
@@ -124,7 +124,7 @@
                     }
                 },
                 "Component_[719105957098091502]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 719105957098091502,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_D.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_D.prefab
@@ -134,7 +134,7 @@
                     "Parent Entity": "ContainerEntity"
                 },
                 "Component_[15060017216590314557]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15060017216590314557,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_E.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_E.prefab
@@ -63,7 +63,7 @@
                     "Id": 11080605254888125912
                 },
                 "Component_[11539580132497996469]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11539580132497996469,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathA_F.prefab
@@ -182,7 +182,7 @@
                     "Id": 5749582277842070449
                 },
                 "Component_[974638327486860372]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 974638327486860372,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathB_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathB_A.prefab
@@ -138,7 +138,7 @@
                     }
                 },
                 "Component_[12844251534414039412]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12844251534414039412,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathB_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathB_B.prefab
@@ -116,7 +116,7 @@
                     "Id": 16873967892157420693
                 },
                 "Component_[16918393744523179920]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16918393744523179920,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathB_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_PathB_F.prefab
@@ -67,7 +67,7 @@
                     "Id": 1355348289001320413
                 },
                 "Component_[15176373982360899010]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15176373982360899010,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Planter_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Planter_A.prefab
@@ -212,7 +212,7 @@
                     }
                 },
                 "Component_[9788397958388067776]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 9788397958388067776,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Planter_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Planter_C.prefab
@@ -190,7 +190,7 @@
                     "Id": 7293090496118334717
                 },
                 "Component_[8652167536069500392]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8652167536069500392,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_A.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_A.prefab
@@ -123,7 +123,7 @@
                     }
                 },
                 "Component_[4911263830307088754]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4911263830307088754,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -354,7 +354,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -462,7 +462,7 @@
                     ]
                 },
                 "Component_[7613192899048161639]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7613192899048161639,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_B.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_B.prefab
@@ -201,7 +201,7 @@
                     "Id": 9132088475316543183
                 },
                 "Component_[9878041068601281004]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 9878041068601281004,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -365,7 +365,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -471,7 +471,7 @@
                     }
                 },
                 "Component_[4911263830307088754]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4911263830307088754,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_C.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_C.prefab
@@ -161,7 +161,7 @@
                     }
                 },
                 "Component_[15513474309903636219]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15513474309903636219,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -355,7 +355,7 @@
                     }
                 },
                 "Component_[15513474309903636219]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15513474309903636219,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -495,7 +495,7 @@
                     }
                 },
                 "Component_[16600950351476123770]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16600950351476123770,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -743,7 +743,7 @@
                     }
                 },
                 "Component_[15513474309903636219]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15513474309903636219,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_D.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_D.prefab
@@ -198,7 +198,7 @@
                     "Id": 8592578248266994102
                 },
                 "Component_[8759779471089011260]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8759779471089011260,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -383,7 +383,7 @@
                     "Id": 8592578248266994102
                 },
                 "Component_[8759779471089011260]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8759779471089011260,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -537,7 +537,7 @@
                     }
                 },
                 "Component_[1637529680644366470]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1637529680644366470,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_E.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_E.prefab
@@ -136,7 +136,7 @@
                     "Id": 5438235668445147617
                 },
                 "Component_[6422202030432622276]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6422202030432622276,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -326,7 +326,7 @@
                     "Id": 5438235668445147617
                 },
                 "Component_[6422202030432622276]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6422202030432622276,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -443,7 +443,7 @@
                     "Id": 11065151952775899519
                 },
                 "Component_[11584592478926341729]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11584592478926341729,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -680,7 +680,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11882972241381921570]/Transform Data/Translate/1",
-                    "value": 10.180938720703125
+                    "value": 10.180938720703123
                 },
                 {
                     "op": "replace",
@@ -745,7 +745,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11882972241381921570]/Transform Data/Translate/0",
-                    "value": 3.8286666870117188
+                    "value": 3.8286666870117183
                 },
                 {
                     "op": "replace",

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_F.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_F.prefab
@@ -193,7 +193,7 @@
                     }
                 },
                 "Component_[4911263830307088754]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4911263830307088754,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -379,7 +379,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -565,7 +565,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -642,7 +642,7 @@
                     ]
                 },
                 "Component_[2362715359467432924]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2362715359467432924,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -968,7 +968,7 @@
                     }
                 },
                 "Component_[4911263830307088754]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4911263830307088754,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_G.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Road_G.prefab
@@ -181,7 +181,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -283,7 +283,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -569,7 +569,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -865,7 +865,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1229,7 +1229,7 @@
                     }
                 },
                 "Component_[4911263830307088754]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4911263830307088754,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1339,7 +1339,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1506,7 +1506,7 @@
                     ]
                 },
                 "Component_[17113275507305774079]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17113275507305774079,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1781,7 +1781,7 @@
                     }
                 },
                 "Component_[6843578227184214245]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6843578227184214245,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -2061,7 +2061,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11882972241381921570]/Transform Data/Translate/0",
-                    "value": -15.126733779907227
+                    "value": -15.126733779907228
                 },
                 {
                     "op": "replace",

--- a/Gems/level_art_mps/Assets/AgPlatform/AgPlatform.prefab
+++ b/Gems/level_art_mps/Assets/AgPlatform/AgPlatform.prefab
@@ -114,7 +114,7 @@
                     "Id": 6407341161487741750
                 },
                 "Component_[6553472109432190231]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6553472109432190231,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/AgPlatform/largeagplatform.prefab
+++ b/Gems/level_art_mps/Assets/AgPlatform/largeagplatform.prefab
@@ -110,7 +110,7 @@
                     "Id": 5881508764027456744
                 },
                 "Component_[6210812951853337619]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6210812951853337619,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/Barrel01/Barrel001.prefab
+++ b/Gems/level_art_mps/Assets/Barrel01/Barrel001.prefab
@@ -143,7 +143,7 @@
                     }
                 },
                 "Component_[7400724477359485941]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7400724477359485941,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/Barrel01/Barrel01.prefab
+++ b/Gems/level_art_mps/Assets/Barrel01/Barrel01.prefab
@@ -86,7 +86,7 @@
                     "Id": 13037140737516961819
                 },
                 "Component_[14277864073025928875]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14277864073025928875,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/Barrel02/Barrel02.prefab
+++ b/Gems/level_art_mps/Assets/Barrel02/Barrel02.prefab
@@ -59,7 +59,7 @@
                     "Id": 12970579640672433133
                 },
                 "Component_[15131520516109470746]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15131520516109470746,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/BoxwoodPlanter/BoxwoodPlanter.prefab
+++ b/Gems/level_art_mps/Assets/BoxwoodPlanter/BoxwoodPlanter.prefab
@@ -87,7 +87,7 @@
                     }
                 },
                 "Component_[13770459485288326894]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13770459485288326894,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/BubbleGun/bubblegun.prefab
+++ b/Gems/level_art_mps/Assets/BubbleGun/bubblegun.prefab
@@ -113,7 +113,7 @@
                     "Id": 6972141049432216624
                 },
                 "Component_[7067552367664259293]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7067552367664259293,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/Crate/Crate.prefab
+++ b/Gems/level_art_mps/Assets/Crate/Crate.prefab
@@ -80,7 +80,7 @@
                     ]
                 },
                 "Component_[13428169775885427600]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13428169775885427600,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/Crate/mediumcrate.prefab
+++ b/Gems/level_art_mps/Assets/Crate/mediumcrate.prefab
@@ -113,7 +113,7 @@
                     }
                 },
                 "Component_[18133601253046655915]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 18133601253046655915,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/Crate/smallcrate.prefab
+++ b/Gems/level_art_mps/Assets/Crate/smallcrate.prefab
@@ -74,7 +74,7 @@
                     "Id": 1051697174901691759
                 },
                 "Component_[16306428596482981108]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16306428596482981108,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/DeciduousPlanter/DeciduousPlanter.prefab
+++ b/Gems/level_art_mps/Assets/DeciduousPlanter/DeciduousPlanter.prefab
@@ -55,7 +55,7 @@
             "Name": "deciduousplanter",
             "Components": {
                 "Component_[11447800962183446324]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11447800962183446324,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/DefenceTurret/DefenseTurret.prefab
+++ b/Gems/level_art_mps/Assets/DefenceTurret/DefenseTurret.prefab
@@ -63,7 +63,7 @@
                     "Id": 13823397236224620794
                 },
                 "Component_[15098578983899491307]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15098578983899491307,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/EBarricade/EBarricade.prefab
+++ b/Gems/level_art_mps/Assets/EBarricade/EBarricade.prefab
@@ -55,7 +55,7 @@
             "Name": "EBarricade",
             "Components": {
                 "Component_[11567975610932433476]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11567975610932433476,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/EBarricade/EBarricade_Small.prefab
+++ b/Gems/level_art_mps/Assets/EBarricade/EBarricade_Small.prefab
@@ -99,7 +99,7 @@
                     "Id": 13336266335757104179
                 },
                 "Component_[14638501835664819504]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14638501835664819504,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/E_Barricade/EBarricade_Small.prefab
+++ b/Gems/level_art_mps/Assets/E_Barricade/EBarricade_Small.prefab
@@ -63,7 +63,7 @@
                     "Id": 13336266335757104179
                 },
                 "Component_[14638501835664819504]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14638501835664819504,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/EnergyCollector/EnergyCollector.prefab
+++ b/Gems/level_art_mps/Assets/EnergyCollector/EnergyCollector.prefab
@@ -130,7 +130,7 @@
                     "Id": 3205004283760294147
                 },
                 "Component_[3680589033456825559]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3680589033456825559,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/JumpPad/jumppad.prefab
+++ b/Gems/level_art_mps/Assets/JumpPad/jumppad.prefab
@@ -86,7 +86,7 @@
                     "Id": 14602108600851001959
                 },
                 "Component_[14766259045021778464]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14766259045021778464,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/LEC30d/LEC30d.prefab
+++ b/Gems/level_art_mps/Assets/LEC30d/LEC30d.prefab
@@ -160,7 +160,7 @@
                     "Id": 7321217677255059796
                 },
                 "Component_[7456320538593033876]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7456320538593033876,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/LEC45d/LEC45d.prefab
+++ b/Gems/level_art_mps/Assets/LEC45d/LEC45d.prefab
@@ -68,7 +68,7 @@
                     "Parent Entity": "ContainerEntity"
                 },
                 "Component_[11062343079787247229]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11062343079787247229,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/LECT/LECT.prefab
+++ b/Gems/level_art_mps/Assets/LECT/LECT.prefab
@@ -112,7 +112,7 @@
                     }
                 },
                 "Component_[3398698983669265824]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3398698983669265824,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/LECstraight/LECstraight.prefab
+++ b/Gems/level_art_mps/Assets/LECstraight/LECstraight.prefab
@@ -135,7 +135,7 @@
                     }
                 },
                 "Component_[3041854279692664654]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3041854279692664654,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/LargeBush/LargeBush.prefab
+++ b/Gems/level_art_mps/Assets/LargeBush/LargeBush.prefab
@@ -64,7 +64,7 @@
                     "Parent Entity": "ContainerEntity"
                 },
                 "Component_[10779275092302294374]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 10779275092302294374,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/LargeBush/SmallBush.prefab
+++ b/Gems/level_art_mps/Assets/LargeBush/SmallBush.prefab
@@ -140,7 +140,7 @@
                     "Id": 3827226759309969581
                 },
                 "Component_[6756982386435152427]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6756982386435152427,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/MalfunctioningShieldGenerator/mshieldgen.prefab
+++ b/Gems/level_art_mps/Assets/MalfunctioningShieldGenerator/mshieldgen.prefab
@@ -76,7 +76,7 @@
                     "Id": 13851468120070323071
                 },
                 "Component_[15617014590518523349]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15617014590518523349,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/O3DETopiary/O3DETopiary.prefab
+++ b/Gems/level_art_mps/Assets/O3DETopiary/O3DETopiary.prefab
@@ -119,7 +119,7 @@
                     "Id": 3723005871881359850
                 },
                 "Component_[5377021004690611554]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 5377021004690611554,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/level_art_mps/Assets/Teleporter_Platform/Teleporter.prefab
+++ b/Gems/level_art_mps/Assets/Teleporter_Platform/Teleporter.prefab
@@ -55,7 +55,7 @@
             "Name": "Teleporter",
             "Components": {
                 "Component_[10112924460877714862]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 10112924460877714862,
                     "ColliderConfiguration": {
                         "MaterialSlots": {


### PR DESCRIPTION
**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725. 
This is currently as draft to avoid submitting it too early.

**Reviewers**
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

**Testing**
All converted prefabs were processed successfully by the Asset Processor. 
Ensured player can run around level and pickup gems.
Confirmed that you can jump off the level and the teleport functions.
Also checked the regular teleport point works.
Checked both in Editor and with server/client launchers

Signed-off-by: moraaar <moraaar@amazon.com>