### PR TITLE
Added a torso and a head hit detection volumes

### DIFF
--- a/Gems/character_mps/Assets/Mixamo/Ybot/ybot.fbx.assetinfo
+++ b/Gems/character_mps/Assets/Mixamo/Ybot/ybot.fbx.assetinfo
@@ -9,7 +9,7 @@
                 "rules": [
                     {
                         "$type": "MetaDataRule",
-                        "metaData": "AdjustActor -actorID $(ACTORID) -name \"YBot\"\nActorSetCollisionMeshes -actorID $(ACTORID) -lod 0 -nodeList \"\"\nAdjustActor -actorID $(ACTORID) -nodesExcludedFromBounds \"\" -nodeAction \"select\"\nAdjustActor -actorID $(ACTORID) -nodeAction \"replace\" -attachmentNodes \"\"\nAdjustActor -actorID $(ACTORID) -mirrorSetup \"\"\n"
+                        "metaData": "AdjustActor -actorID $(ACTORID) -name \"YBot\"\nActorSetCollisionMeshes -actorID $(ACTORID) -lod 0 -nodeList \"\"\nAdjustActor -actorID $(ACTORID) -nodesExcludedFromBounds \"\" -nodeAction \"select\"\nAdjustActor -actorID $(ACTORID) -nodeAction \"replace\" -attachmentNodes \"\"\nAdjustActor -actorID $(ACTORID) -motionExtractionNodeName \"RootNode\"\nAdjustActor -actorID $(ACTORID) -mirrorSetup \"\"\n"
                     },
                     {
                         "$type": "{3CB103B3-CEAF-49D7-A9DC-5A31E2DF15E4} LodRule",


### PR DESCRIPTION
- For simplicity, adding just two large volumes for the body and head of Ybot actor.
- Confirmed that players can shoot each other reliable locally.
![image](https://user-images.githubusercontent.com/5432499/221619810-7e3cd468-2b4e-4dcb-9198-e00bec5af2dc.png)
