### PR TITLE
Add dco.yaml to allow signoff and on behalf of others

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
**What does this PR do?**
Activate an additional function in the DCO app to allow reviewers/maintainers to sign-off on behalf of others.

This will also allow contributors who have changed their Github username or email to remediate their own PRs, as the DCO app considers the new email/username as a separate user.

**How was this PR tested?**
Tested in a forked branch

Signed-off-by: Mike Chang [changml@amazon.com](mailto:changml@amazon.com)