### PR TITLE
Teleporter asset fix

### DIFF
--- a/Gems/level_art_mps/Assets/Teleporter_Platform/Teleporter.prefab
+++ b/Gems/level_art_mps/Assets/Teleporter_Platform/Teleporter.prefab
@@ -79,7 +79,7 @@
                                     "guid": "{EA17489F-60AD-5610-84BB-DA4E1FB675E0}",
                                     "subId": 2308505123
                                 },
-                                "assetHint": "teleporter_platform/teleporter_platform.pxmesh "
+                                "assetHint": "teleporter_platform/teleporter_platform.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {


### PR DESCRIPTION
The teleporter was referencing an invalid physics asset. I fixed it to point to the correct asset.

Verified by:
* Turning on "Draw collider" and seeing that the collider was drawn for the teleporter
* Running AssetBundler and verifying that we no longer got a missing asset error due to this prefab