### PR TITLE
Fixed TeleportFX scriptcanvas path.

### DIFF
--- a/Gems/level_art_mps/Assets/Teleporter_Platform/Teleporter.prefab
+++ b/Gems/level_art_mps/Assets/Teleporter_Platform/Teleporter.prefab
@@ -273,14 +273,14 @@
                     "Id": 2617115515770634840,
                     "configuration": {
                         "sourceHandle": {
-                            "id": "{53D126DE-5316-5A0C-8E97-99426583126E}",
-                            "path": "Assets/Teleporter_Platform/TeleportFX.scriptcanvas"
+                            "id": "{F28F10BC-8F13-5A56-9977-373006E35DCE}",
+                            "path": "Teleporter_Platform/TeleportFX.scriptcanvas"
                         },
                         "sourceName": "TeleportFX.scriptcanvas",
                         "propertyOverrides": {
                             "source": {
-                                "id": "{53D126DE-5316-5A0C-8E97-99426583126E}",
-                                "path": "Assets/Teleporter_Platform/TeleportFX.scriptcanvas"
+                                "id": "{F28F10BC-8F13-5A56-9977-373006E35DCE}",
+                                "path": "Teleporter_Platform/TeleportFX.scriptcanvas"
                             },
                             "overridesUnused": [
                                 {


### PR DESCRIPTION
Multiple warnings were being printed on level load about the TeleportFX.scriptcanvas failing to load and process. This change eliminates the warnings.

I'm not 100% sure what the script canvas _does_, so I can't directly say what has changed with this fix, but presumably the desired effect should now be happening where it wouldn't have been happening before.