### PR TITLE
Player Drop, Combo Gem Model Asset

### DIFF
--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/Gem_combo.fbx
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/Gem_combo.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23d43314a6473f29cb17778f3a99212cd8dd1085262eb83fccec0927f1f59089
+size 235504

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/Maya2023_Gems.mb
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/Maya2023_Gems.mb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf95398539d5156f30a97537ec9c740aedaaf5b464102be2919e1995ba658b1d
-size 2039472
+oid sha256:f443f3137ae4d1ec23af6b36394d83dd6a0e683e77e4668b3f3c87f57d87ed98
+size 2261072

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/gem_combo.prefab
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/gem_combo.prefab
@@ -1,0 +1,233 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "gem_combo",
+        "Components": {
+            "Component_[10248114193553634516]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 10248114193553634516
+            },
+            "Component_[11367704698216157479]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 11367704698216157479
+            },
+            "Component_[1585022935666603325]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 1585022935666603325
+            },
+            "Component_[16496546297203098876]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 16496546297203098876
+            },
+            "Component_[2052791992031710523]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 2052791992031710523,
+                "Child Entity Order": [
+                    "Entity_[44038228262045]"
+                ]
+            },
+            "Component_[3782178925119850169]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3782178925119850169
+            },
+            "Component_[4519162350785178322]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4519162350785178322
+            },
+            "Component_[4811221071627586596]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4811221071627586596,
+                "Parent Entity": ""
+            },
+            "Component_[7542494475005023911]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 7542494475005023911
+            },
+            "Component_[9288058416884071187]": {
+                "$type": "EditorLockComponent",
+                "Id": 9288058416884071187
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[44038228262045]": {
+            "Id": "Entity_[44038228262045]",
+            "Name": "gem_combo",
+            "Components": {
+                "Component_[10048990291894212074]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10048990291894212074
+                },
+                "Component_[12323791579184934806]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12323791579184934806
+                },
+                "Component_[14771576824822104656]": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 14771576824822104656,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 6,
+                            "Color": [
+                                0.9647058844566345,
+                                0.6941176652908325,
+                                0.1764705926179886
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 5.97607946395874
+                        }
+                    }
+                },
+                "Component_[17390637102908529339]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17390637102908529339
+                },
+                "Component_[2125835513692421711]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2125835513692421711
+                },
+                "Component_[3840750316589330119]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 3840750316589330119,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 749070437
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{3D3B1B5A-919F-5272-B349-B386F240A4F5}"
+                                            },
+                                            "assetHint": "pick_ups/gems/skins/gem_interior_red.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1773378494
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{F55EDFEA-D784-546E-9489-9FE7265B8283}"
+                                            },
+                                            "assetHint": "pick_ups/gems/skins/gem_interior_green.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2007229905
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{AD75328E-5545-55E6-97C8-C2E3D627B3E6}"
+                                            },
+                                            "assetHint": "pick_ups/gems/skins/gem_interior_yellow.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2137042421
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{4EE7CFA7-04F3-5D52-872C-46192C145AAF}"
+                                            },
+                                            "assetHint": "pick_ups/gems/skins/gem_exterior_red.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2745205751
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{E42EA630-B22B-5DD2-83DD-9FBD7FAC8FC1}"
+                                            },
+                                            "assetHint": "pick_ups/gems/skins/gem_exterior_yellow.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 3458859696
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{B539B85B-5B81-52E3-95D5-33A0E3C36E29}"
+                                            },
+                                            "assetHint": "pick_ups/gems/skins/gem_exterior_green.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[3939119072551724330]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3939119072551724330
+                },
+                "Component_[4815593335200005365]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4815593335200005365,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "Component_[6986095242662415025]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 6986095242662415025,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{1C0444A0-943C-5802-8F4F-74AB4A427599}",
+                                    "subId": 279381580
+                                },
+                                "assetHint": "pick_ups/gems/gem_combo.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[8264179221822289324]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8264179221822289324,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4815593335200005365
+                        },
+                        {
+                            "ComponentId": 14771576824822104656,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 6986095242662415025,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3840750316589330119,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8522491486388285956]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8522491486388285956
+                },
+                "Component_[8976900130314890664]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8976900130314890664
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR:
1. adds new fbx for a combo gem model
2. adds a previs prefab for the combo gem asset
3. updates the asset test level

![image](https://user-images.githubusercontent.com/23222931/228966857-362e62c0-9f5a-4e50-a62b-4991b0d11c70.png)
