### PR TITLE
lighting tweaks, optimize lamps

### DIFF
--- a/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lamp.prefab
+++ b/Gems/kb3d_mps/Assets/KB3D_HighTechStreets/Prefabs/HTS_Lamp.prefab
@@ -323,7 +323,8 @@
                             "Intensity": 250.0,
                             "AttenuationRadiusMode": 0,
                             "AttenuationRadius": 6.0,
-                            "UseFastApproximation": true
+                            "UseFastApproximation": true,
+                            "Affects GI": false
                         }
                     }
                 },


### PR DESCRIPTION
This PR:
1. changes the Quad lights on lamps to not affect GI

This results in no visual change, but a perf bump within raytracing.
These lights are not bright, they are mainly soft 'emissive lighting', it's the emissive surfaces on the light enclosure (model) that does affect GI and is the main contributor to the bounce lighting seen in the level.