### PR TITLE
Change includes for scene/viewsrg.srgi to scene/viewsrg_all.srgi in all shaders

### DIFF
--- a/Project/Assets/Materials/ArmorPowerUp/ArmorPowerUp.azsl
+++ b/Project/Assets/Materials/ArmorPowerUp/ArmorPowerUp.azsl
@@ -1,5 +1,5 @@
 #pragma once
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #define UNIFIED_FORWARD_OUTPUT
 #include <Atom/Features/PBR/ForwardPassOutput.azsli>


### PR DESCRIPTION
Necessary follow-up for [PR 18566](https://github.com/o3de/o3de/pull/18566) that introduced the scene/viewsrg_all.srgi in the engine as a wrapper around the project-specific scene/viewsrg.srgi.

Note that the O3DEPopcornFXPlugin needs similar changes, but this PR does not modify the submodule link, since the PR to the changes are pending in the other repo as well.