### PR TITLE
Merge from development to main for release 25.05.0

### DIFF
--- a/Project/Assets/Materials/ArmorPowerUp/ArmorPowerUp.azsl
+++ b/Project/Assets/Materials/ArmorPowerUp/ArmorPowerUp.azsl
@@ -1,5 +1,5 @@
 #pragma once
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #define UNIFIED_FORWARD_OUTPUT
 #include <Atom/Features/PBR/ForwardPassOutput.azsli>


### PR DESCRIPTION
Note that this repository did not have a stabilization/25050 branch, but did have some changes in development.

I am merging from development to main.

** REVIEWERS ** do not check each file in this change.  each file has already presumably been through whatever gates it took to get into the `development` branch.

Instead, the goal of this PR is to make `main` identical to `development`, and as such, you can check this automatically by doing 2 things.

1. make sure that this PR targets `main` up top there.  It must be applied to `main`
2. check https://github.com/o3de/o3de-multiplayersample-assets/compare/development...nick-l-o3de:o3de-multiplayersample-assets:merge_from_development_to_main_25050 which compares `development` with this PR.  ** There should be 0 files changed ** since this should be identical.
