### PR TITLE
fix(level_art_mps): correct StandardPBR.materialtype casing on 11 files (Linux case-sensitive FS)

### DIFF
--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/Gem_one_Interior_MAT.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/Gem_one_Interior_MAT.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Blue.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Blue.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 6,
     "propertyValues": {
         "anisotropy.anisotropyAngle": 0.3199999928474426,

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Green.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Green.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 6,
     "propertyValues": {
         "anisotropy.anisotropyAngle": 0.3199999928474426,

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Red.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Red.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 6,
     "propertyValues": {
         "anisotropy.anisotropyAngle": 0.3199999928474426,

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_White.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_White.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 6,
     "propertyValues": {
         "anisotropy.anisotropyAngle": 0.3199999928474426,

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Yellow.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Exterior_Yellow.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 6,
     "propertyValues": {
         "anisotropy.anisotropyAngle": 0.3199999928474426,

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Blue.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Blue.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Green.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Green.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureBlendMode": "Lerp",

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Red.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Red.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_White.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_White.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [

--- a/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Yellow.material
+++ b/Gems/level_art_mps/Assets/Pick_Ups/Gems/skins/Gem_Interior_Yellow.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureBlendMode": "Lerp",


### PR DESCRIPTION
## Summary

- Renames the `materialType` reference in eleven `.material` files from `standardpbr.materialtype` (lowercase) to `StandardPBR.materialtype` (CamelCase, matching the file the engine actually ships).
- Behavior unchanged on Windows + macOS (case-insensitive filesystems silently folded both spellings to the same file).
- Fixes the AssetProcessorBatch failure on Linux + any case-sensitive filesystem.

Fixes #176.

## Detail

Affected files (all under `Gems/level_art_mps/Assets/Pick_Ups/Gems[/skins]/`):

```
Gem_one_Interior_MAT.material
skins/Gem_Exterior_Blue.material
skins/Gem_Exterior_Green.material
skins/Gem_Exterior_Red.material
skins/Gem_Exterior_White.material
skins/Gem_Exterior_Yellow.material
skins/Gem_Interior_Blue.material
skins/Gem_Interior_Green.material
skins/Gem_Interior_Red.material
skins/Gem_Interior_White.material
skins/Gem_Interior_Yellow.material
```

Each file's only change is the `materialType` line:

```diff
-    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/standardpbr.materialtype",
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
```

The other 175 `.material` files in the `level_art_mps` Gem already use the correct `StandardPBR.materialtype` spelling, so this brings the gem to internal consistency.

Same bug exists on `main` and `stabilization/25100`; cherry-pick recommended.

## Test plan

- [x] Pre-fix: `AssetProcessorBatch --project-path=<MultiplayerSample>` reports 19 failed jobs on Linux, all in this asset cohort.
- [x] Diff is mechanical: 11 files, one line changed per file, 11 insertions, 11 deletions.
- [x] No other content changed; no JSON-schema differences; `materialTypeVersion` is unchanged in every file.
- [ ] Post-fix: AP batch processes the cohort cleanly. (Requires a fresh AP cache + rebuild on the reviewer's end to verify, OR I can run my Tier 9 packaging test against the fix branch and report.)

## Discovery context

Caught via an O3DE Linux RPM packaging integration test running a full AP batch against the installed engine for o3de-multiplayersample. Of 1612 total AP jobs, 1593 succeeded and 19 failed -- all 19 in this one cohort. Hundreds of other PBR materials elsewhere in the project processed correctly through the same `MaterialUtils::LoadMaterialTypeSourceData` path with `StandardPBR.materialtype` correctly-cased, isolating the case mismatch as the sole cause.

Tested on Fedora 44 against an engine RPM built from `stabilization/26050 @ 246b46f5`.